### PR TITLE
More offensive recruiters plus a script to allow-list 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+allowlisted.txt

--- a/README.md
+++ b/README.md
@@ -7,12 +7,21 @@ into email server blacklists. Pull requests welcome!
 
 # Usage
 
+### Automatic importing
+
 Use https://github.com/jasoncartwright/recruiterdomains/blob/master/domains.txt
 or https://raw.githubusercontent.com/jasoncartwright/recruiterdomains/master/domains.txt
 for automatic importing to your mail server.
+
+### Allow-listing domains
 
 If there are recruiter domains that you'd like to keep, add them to an
 `allowlisted.txt` file then print a combined list to STDOUT via:
 
     $ make
 
+### G-Suite integration
+
+To block a list of senders in G-Suite, navigate to the `Apps > G Suite >
+Settings for Gmail > Advanced settings` section and look for the "Blocked
+senders" section.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
 # Recruiter Domains
 
-List of domain names of known recruitment consultants. Suitable to be imported into email server blacklists. Pull requests welcome!
-
-Domain are in https://github.com/jasoncartwright/recruiterdomains/blob/master/domains.txt or https://raw.githubusercontent.com/jasoncartwright/recruiterdomains/master/domains.txt for automatic importing to your mail server.
+List of domain names of known recruitment consultants. Suitable to be imported
+into email server blacklists. Pull requests welcome!
 
 [![Build Status](https://travis-ci.org/jasoncartwright/recruiterdomains.svg?branch=master)](https://travis-ci.org/jasoncartwright/recruiterdomains)
+
+# Usage
+
+Use https://github.com/jasoncartwright/recruiterdomains/blob/master/domains.txt
+or https://raw.githubusercontent.com/jasoncartwright/recruiterdomains/master/domains.txt
+for automatic importing to your mail server.
+
+If there are recruiter domains that you'd like to keep, add them to an
+`allowlisted.txt` file then print a combined list to STDOUT via:
+
+    $ make
+

--- a/domains.txt
+++ b/domains.txt
@@ -3,12 +3,14 @@
 2kpeople.co.uk
 365rec.com
 3aaa.co.uk
+JustIT.co.uk
 aatomrecruitment.com
 abrs.com
 absoluteitrecruitment.com
 adgold.co.uk
 adlib-recruitment.co.uk
 agendarecruitment.co.uk
+albertbow.com
 amicusjobs.co.uk
 andiamo-group.com
 applauseit.co.uk
@@ -38,6 +40,7 @@ certusrecruitment.com
 chassamrecruitment.co.uk
 chromarecruitment.com
 circlerecruitment.com
+cisinlabs.com
 cititec.com
 compfutures.com
 computerfutures.com
@@ -48,6 +51,7 @@ continuoussolutions.co
 contractrecruit.co.uk
 costelloandreyes.com
 cpsgroupuk.com
+creative-cx.com
 creativepersonnel.co.uk
 criticalpathsolutions.co.uk
 ctprecruitment.co.uk
@@ -61,6 +65,7 @@ doyouknowbonobo.co.uk
 e-recruiter.co.uk
 edison-hill.co.uk
 ejspecialists.com
+emails.econsultancy.com
 emponics.com
 energizerec.com
 engagewithus.com
@@ -91,6 +96,7 @@ globalresourcingsolutions.co.uk
 gopartnership.com
 gregoryjamesresourcing.com
 greywood.co.uk
+growin.com
 gurucareers.com
 hackajob.co
 hamilton-fraser.co.uk
@@ -134,7 +140,7 @@ jitr.co.uk
 jjnmedia.com
 jonothanbosworth.co.uk
 jp-jobs.com
-JustIT.co.uk
+kitehumancapital.com
 knowit.co.uk
 korusgroup.co.uk
 lafosse.com
@@ -146,6 +152,7 @@ lawrenceharvey.com
 libertyresourcing.co.uk
 loveworklife.com
 lynxrecruitment.co.uk
+macgregorblack.com
 macleanmoore.com
 madisonts.com
 majorplayers.co.uk
@@ -170,6 +177,7 @@ nicollcurtin.com
 novate-it.co.uk
 oakleafpartnership.com
 oho.co.uk
+ohogroupuk.com
 oliverbernard.co.uk
 onboardrecruitment.com
 optimum-digital.com
@@ -200,11 +208,13 @@ profilescreative.com
 prosper-is.com
 puredevelopers.co.uk
 purple-consultancy.com
+qa.com
 qarea.com
 radleyjames.com
 randstad.co.uk
 realit.com
 recann.uk
+recogroup.co.uk
 recruitmentgenius.com
 redrockconsulting.co.uk
 redsevenuk.com
@@ -219,6 +229,7 @@ senitor.com
 serendipityrecruitment.com
 simplifiedrecruitment.com
 skillfindergroup.com
+skysoftglobal.com
 socialheads.co.uk
 sourcecoders.io
 sourced.ai
@@ -236,15 +247,21 @@ talentedge.co.uk
 talentinternational.co.uk
 talentsourceglobal.co.uk
 talktoneon.com
+tau-search.com
 technet-it.co.uk
 technicaltalent.co.uk
 technology-leaders.com
+ten10.com
+thirdrepublic.com
 tmsilver.com
 transition-partners.co.uk
 triarecruitment.com
 trsgroup.co.uk
+trustinsoda.com
+twentyrecruitment.com
 unifyndgroup.com
 unitingambition.com
+vanta.com
 vemployee.com
 venngroup.com
 venturi-group.com
@@ -260,6 +277,7 @@ webhiring.co.uk
 webpointresources.com
 welovesalt.com
 wesourcetalent.com
+wundertalent.co.uk
 x4group.co.uk
 x4technology.co.uk
 xactplacements.co.uk

--- a/makefile
+++ b/makefile
@@ -1,0 +1,4 @@
+SHELL := /bin/bash
+
+combined_file:
+	comm -13 <(grep "[^#].*\." allowlisted.txt | sort) <(sort domains.txt)


### PR DESCRIPTION
Have added a load more domains in one commit — let me know if you'd prefer one commit per host.

We also actually work with some of these spam-lords so we occassionally have to remove a domain from the block-list. To that end, I've added a simple `make` target that lets you an uncomitted `allowlisted.txt` file to build a combined list.

Added a note on G-Suite integration too which might help others get started too.